### PR TITLE
loadLanguageFile() before loadDataContainer()

### DIFF
--- a/BackendBreadcrumb.php
+++ b/BackendBreadcrumb.php
@@ -52,8 +52,8 @@ class BackendBreadcrumb extends Backend
                     $table = $GLOBALS['BE_MOD'][$moduleGroup][$do]['tables'][0];
                 }
 
-                $this->loadDataContainer($table);
-                $this->loadLanguageFile($table);
+	            $this->loadLanguageFile($table);
+	            $this->loadDataContainer($table);
                 $level = array
                 (
                     'id'          => $id,


### PR DESCRIPTION
If there is no important reason to use this order, it would be the solution to have translated labels also for the multiColumnWizard-Input types. Otherwise there is missing the language-array-element for
multiColumnWizard at least in extended tl_content dca-File.
